### PR TITLE
Update build.yml to add a timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         if: github.ref == 'refs/heads/main'
         permissions:
             packages: write


### PR DESCRIPTION
saw the action was running a long time so I added a timeout 
<img width="1193" alt="image" src="https://github.com/marigarey/canvas-notion-integration/assets/34144122/dd725bac-3601-4847-b47a-edd27b9c40eb">

you probably have to manually cancel the existing run though [here](https://github.com/marigarey/canvas-notion-integration/actions/runs/9628984878/job/26557825289)