### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
             - main
     pull_request:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -27,16 +31,23 @@ jobs:
                 name: Login to GitHub Container Registry
                 uses: docker/login-action@v3
                 with:
-                    registry: ghcr.io
+                    registry: ${{ env.REGISTRY }}
                     username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
-            - 
+            -
+                name: Extract metadata for Docker
+                id: meta
+                uses: docker/metadata-action@v5
+                with:
+                    images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            -
                 name: Build and Push Docker Image
                 uses: docker/build-push-action@v6
                 with:
                     context: .
                     platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
                     push: true
-                    tags: ghcr.io/${{ github.repository }}:latest
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
                     cache-from: type=gha
                     cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
                 uses: docker/build-push-action@v6
                 with:
                     context: .
-                    platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+                    platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
                     push: true
                     tags: ghcr.io/${{ github.repository }}:latest
                     cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@
 # Comments are provided throughout this file to help you get started.
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/
-FROM node:alpine3.19
+
+# Do not upgrade node past 18
+# Blocked by https://github.com/docker/build-push-action/issues/1071
+FROM node:18.19.1-alpine
 # Use production node environment by default.
 ENV NODE_ENV production
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ docker -t canvas-notion-integration build .
 > - `linux/arm/v6`
 > - `linux/arm/v7`
 > - `linux/arm64`
-> - `linux/ppc64le`
-> - `linux/s390x`
 
 ### 2. Canvas Token Access
 


### PR DESCRIPTION
This PR should fix the Docker build workflow.

To do that, it:

- Drops broken platforms
  It looks like `linux/ppc64le` and `linux/s390x` are lost causes.
- Pins Node to v18 in the Dockerfile
  This is because Node builds on certain platforms emulated with QEMU are broken when using a Node version greater than 18. See https://github.com/docker/build-push-action/issues/1071 for more info.
- Modifies image metadata generation
  This just fixes an issue I had testing the workflow on my fork, but it's probably a good practice anyway.